### PR TITLE
Update more items

### DIFF
--- a/free_software_items.rq
+++ b/free_software_items.rq
@@ -1,9 +1,7 @@
 PREFIX schema: <http://schema.org/>
 
 SELECT ?project ?projectLabel ?article ?repo WHERE {
-  # Free Software projects
-  ?project p:P31/ps:P31 wd:Q341.
-
+  # Items with a repo on github
   ?project wdt:P1324 ?repo.
 
   # Exclude projects not hosted on github

--- a/free_software_items.rq
+++ b/free_software_items.rq
@@ -10,8 +10,10 @@ SELECT ?project ?projectLabel ?article ?repo WHERE {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en" . }
 
   # Get the corresponding wikipedia page
-  ?article schema:about ?project .
-  ?article schema:inLanguage "en" .
-  ?article schema:isPartOf <https://en.wikipedia.org/>
+  OPTIONAL {
+    ?article schema:about ?project .
+    ?article schema:inLanguage "en" .
+    ?article schema:isPartOf <https://en.wikipedia.org/>
+  }
 }
 ORDER BY ?projectLabel

--- a/main.py
+++ b/main.py
@@ -360,6 +360,8 @@ def update_wikipedia(combined_properties):
     :param combined_properties: dict
     :return:
     """
+    if "article" not in combined_properties:
+        return
     q_value = combined_properties["article"].replace("https://en.wikipedia.org/wiki/", "")
     page = pywikibot.Page(pywikibot.Site("en", "wikipedia"), q_value)
     text = page.text


### PR DESCRIPTION
This PR changes two things:
- It is not necessary for an item to have an article in English Wikipedia to have the versions on Wikidata updated
- It is not necessary for an item to be an instance of Q341 (free software) – important since lots of (free) software is not classified as free software but in similar but distinct ways.

Together these patches increase the number of matched items from 325 to 1560.