### PR TITLE
Support other protocols

### DIFF
--- a/free_software_items.rq
+++ b/free_software_items.rq
@@ -5,7 +5,7 @@ SELECT ?project ?projectLabel ?article ?repo WHERE {
   ?project wdt:P1324 ?repo.
 
   # Exclude projects not hosted on github
-  FILTER(STRSTARTS(STR(?repo), "https://github.com")).
+  FILTER(contains(STR(?repo), "://github.com/")).
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en" . }
 

--- a/main.py
+++ b/main.py
@@ -66,8 +66,7 @@ def normalize_url(url):
     :return:
     """
     url = url.strip("/")
-    url = url.replace("http://", "https://")
-    url = url.replace("git://", "https://")
+    url = "https://" + url.split("://")[1]
     if url.endswith('.git'):
         url = url[:-4]
     return url

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ class Settings:
     calendarmodel = pywikibot.Site().data_repository().calendarmodel()
     wikidata_repo = pywikibot.Site("wikidata", "wikidata").data_repository()
 
-    repo_regex = re.compile(r"https://github.com/[^/]+/[^/]+")
+    repo_regex = re.compile(r"[a-z]+://github.com/[^/]+/[^/]+")
     version_regex = re.compile(r"\d+(\.\d+)+")
     unmarked_prerelease_regex = re.compile(r"[ -._\d](b|r|rc|beta|alpha)([ .\d].*)?$", re.IGNORECASE)
 
@@ -53,20 +53,21 @@ def github_repo_to_api(url):
 
 def github_repo_to_api_releases(url):
     """Converts a github repoository url to the api entry with the releases"""
-    url = normalize_url(url)
-    url = url.replace("https://github.com/", "https://api.github.com/repos/")
+    url = github_repo_to_api(url)
     url += "/releases"
     return url
 
 
 def normalize_url(url):
     """
-    Canonical urls be like: no slash, no file extension
+    Canonical urls be like: https, no slash, no file extension
 
     :param url:
     :return:
     """
     url = url.strip("/")
+    url = url.replace("http://", "https://")
+    url = url.replace("git://", "https://")
     if url.endswith('.git'):
         url = url[:-4]
     return url


### PR DESCRIPTION
This addresses #6 – support repo-urls with http or git as protocol.
This increases the number of items checked from 1804 to 2141 (+19%).