### PR TITLE
Fallback to tags

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,6 +88,13 @@ def github_repo_to_api_releases(url):
     return url
 
 
+def github_repo_to_api_tags(url):
+    """Converts a github repository url to the api entry with the tags"""
+    url = github_repo_to_api(url)
+    url += "/tags"
+    return url
+
+
 def normalize_url(url):
     """
     Canonical urls be like: https, no slash, no file extension
@@ -100,6 +107,17 @@ def normalize_url(url):
     if url.endswith(".git"):
         url = url[:-4]
     return url
+
+
+def string_to_wddate(isotimestamp):
+    date = pywikibot.WbTime.fromTimestr(
+        isotimestamp, calendarmodel=Settings.calendarmodel
+    )
+    date.hour = 0
+    date.minute = 0
+    date.second = 0
+    date.precision = pywikibot.WbTime.PRECISION["day"]
+    return date
 
 
 def _get_or_create(method, all_objects, repo, p_value, value):
@@ -282,13 +300,7 @@ def analyse_release(release: dict, project_name: str) -> Optional[dict]:
         release_type = "unstable"
 
     # Convert github's timestamps to wikidata dates
-    date = pywikibot.WbTime.fromTimestr(
-        release["published_at"], calendarmodel=Settings.calendarmodel
-    )
-    date.hour = 0
-    date.minute = 0
-    date.second = 0
-    date.precision = pywikibot.WbTime.PRECISION["day"]
+    date = string_to_wddate(release["published_at"])
 
     return {
         "version": version,
@@ -315,14 +327,7 @@ def get_data_from_github(url, properties):
     # "retrieved" does only accept dates without time, so create a timestamp with no date
     # noinspection PyUnresolvedReferences
     isotimestamp = pywikibot.Timestamp.utcnow().toISOformat()
-    date = pywikibot.WbTime.fromTimestr(
-        isotimestamp, calendarmodel=Settings.calendarmodel
-    )
-    date.hour = 0
-    date.minute = 0
-    date.second = 0
-    date.precision = pywikibot.WbTime.PRECISION["day"]
-    properties["retrieved"] = date
+    properties["retrieved"] = string_to_wddate(isotimestamp)
 
     # General project information
     project_info = get_json_cached(github_repo_to_api(url))

--- a/main.py
+++ b/main.py
@@ -382,17 +382,17 @@ def get_data_from_github(url, properties):
 
     apiurl = github_repo_to_api_releases(url)
     releases = get_all_pages(apiurl)
-    analyse = analyse_release
+
     if Settings.read_tags and len(releases) == 0:
         logger.info("Falling back to tags.")
         apiurl = github_repo_to_api_tags(url)
         releases = get_all_pages(apiurl)
-        analyse = analyse_tag
+        extracted = [analyse_tag(release, project_info) for release in releases]
+    else:
+        extracted = [analyse_release(release, project_info) for release in releases]
 
     properties["stable_release"] = []
-    for release in releases:
-        extract = analyse(release, project_info)
-
+    for extract in extracted:
         if extract and extract["release_type"] == "stable":
             properties["stable_release"].append(extract)
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import re
 from distutils.version import LooseVersion
 from json.decoder import JSONDecodeError
 from typing import Optional
-from urllib.parse import urlencode
+from urllib.parse import quote_plus
 
 import mwparserfromhell
 import pywikibot
@@ -327,7 +327,7 @@ def analyse_tag(release: dict, project_info: dict) -> Optional[dict]:
     date = string_to_wddate(
         get_json_cached(release["commit"]["url"])["commit"]["committer"]["date"]
     )
-    html_url = project_info["html_url"] + "/releases/tag/" + urlencode(release["name"])
+    html_url = project_info["html_url"] + "/releases/tag/" + quote_plus(release["name"])
 
     return {
         "version": version,

--- a/main.py
+++ b/main.py
@@ -114,6 +114,9 @@ def normalize_url(url):
 
 
 def string_to_wddate(isotimestamp):
+    """
+    Create a wikidata compatible wikibase date from an ISO 8601 timestamp
+    """
     date = pywikibot.WbTime.fromTimestr(
         isotimestamp, calendarmodel=Settings.calendarmodel
     )
@@ -208,6 +211,9 @@ def get_or_create_sources(repo, claim, url, retrieved, title=None, date=None):
 
 
 def get_json_cached(url):
+    """
+    Get JSON from an API and cache the result
+    """
     response = Settings.cached_session.get(url)
     response.raise_for_status()
     try:
@@ -269,7 +275,10 @@ def get_all_pages(url: str):
 
 
 def analyse_release(release: dict, project_info: dict) -> Optional[dict]:
-    """ Heuristics to find the version number """
+    """
+    Heuristics to find the version number and according meta-data for a release
+    marked with githubs release-feature
+    """
     project_name = project_info["name"]
     match_tag_name = extract_version(release.get("tag_name") or "", project_name)
     match_name = extract_version(release.get("name") or "", project_name)
@@ -315,7 +324,13 @@ def analyse_release(release: dict, project_info: dict) -> Optional[dict]:
 
 
 def analyse_tag(release: dict, project_info: dict) -> Optional[dict]:
-    """ Heuristics to find the version number """
+    """
+    Heuristics to find the version number and according meta-data for a release
+    not marked with githubs release-feature but tagged with git.
+
+    Compared to analyse_release this needs an extra API-call which makes this
+    function considerably slower.
+    """
     project_name = project_info["name"]
     match_name = extract_version(release.get("name") or "", project_name)
     if match_name is not None:
@@ -339,10 +354,13 @@ def analyse_tag(release: dict, project_info: dict) -> Optional[dict]:
 
 def get_data_from_github(url, properties):
     """
-    Retrieve the following data from github. Sets it to None if none was given by github
+    Retrieve the following data from github:
      - website / homepage
      - version number string and release date of all stable releases
-     - version number string and release date of all prereleases
+
+    Version marked with githubs own release-function are received primarily.
+    Only if a project has none releases marked that way this function will fall
+    back to parsing the tags of the project.
 
     All data is preprocessed, i.e. the version numbers are extracted and
     unmarked prereleases are discovered

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import re
 from distutils.version import LooseVersion
 from json.decoder import JSONDecodeError
 from typing import Optional
+from urllib.parse import urlencode
 
 import mwparserfromhell
 import pywikibot
@@ -326,7 +327,7 @@ def analyse_tag(release: dict, project_info: dict) -> Optional[dict]:
     date = string_to_wddate(
         get_json_cached(release["commit"]["url"])["commit"]["committer"]["date"]
     )
-    html_url = project_info["html_url"] + "/releases/tag/" + release["name"]
+    html_url = project_info["html_url"] + "/releases/tag/" + urlencode(release["name"])
 
     return {
         "version": version,

--- a/main.py
+++ b/main.py
@@ -518,7 +518,9 @@ def update_wikidata(properties):
             latest_version = None
 
     if len(stable_releases) > 100:
-        logger.warning("Adding only 100 stable releases of ", len(stable_releases))
+        logger.warning(
+            "Adding only 100 stable releases of {}".format(len(stable_releases))
+        )
         stable_releases = stable_releases[-100:]
     else:
         logger.info("Adding {} stable releases:".format(len(stable_releases)))

--- a/tools.py
+++ b/tools.py
@@ -2,15 +2,11 @@
 import argparse
 import json
 from random import sample
-from typing import Iterable, Dict
+from typing import Dict, Iterable
 
-from main import (
-    Settings,
-    analyse_release,
-    get_all_github_releases,
-    logger,
-    query_projects,
-)
+from main import (Settings, analyse_release, get_all_pages, get_json_cached,
+                  github_repo_to_api, github_repo_to_api_releases, logger,
+                  query_projects)
 
 
 def safe_sample(population: Iterable[Dict[str, str]], size: int):
@@ -28,11 +24,13 @@ def debug_version_handling(
     if not no_sampling:
         projects = safe_sample(projects, threshold)
     for project in projects:
-        github_releases = get_all_github_releases(project["repo"])
+        project_info = get_json_cached(github_repo_to_api(project["repo"]))
+        apiurl = github_repo_to_api_releases(project["repo"])
+        github_releases = get_all_pages(apiurl)
         if not no_sampling:
             github_releases = safe_sample(github_releases, size)
         for github_release in github_releases:
-            release = analyse_release(github_release, project["projectLabel"])
+            release = analyse_release(github_release, project_info)
             print(
                 "{:15} | {:10} | {:20} | {:25} | {}".format(
                     release["version"] if release else "---",


### PR DESCRIPTION
I rewrote the support for tags as source of releases instead if githubs release-system. Tags will only be used if the application has never used the releases-system to avoid false-positives.

Maybe you already want to have a look?