### PR TITLE
Add support for a blacklist-page

### DIFF
--- a/user-config.py
+++ b/user-config.py
@@ -1,7 +1,7 @@
 import json
 
 family = "wikidata"
-mylang = "test"  # Nonsense for required field
+mylang = "wikidata"  # Needed for editing of userpages
 with open("config.json") as config:
     username = json.load(config)["username"]
     usernames["wikidata"]["wikidata"] = username


### PR DESCRIPTION
No matter how good our version parser is, latest with #35 chances are that we run into some hard-to-fix false positives, to be able to quickly react on such cases without stopping the bot. I propose to have a [page in Wikidata-Usernamespace](https://www.wikidata.org/wiki/User:Github-wiki-bot/Exceptions) where Q-IDs can be added by every Wikidata-Editors to make github-wiki-bot skip these items.