### PR TITLE
Fix the order of the versions

### DIFF
--- a/main.py
+++ b/main.py
@@ -411,7 +411,6 @@ def update_wikidata(properties):
     # Add all stable releases
     stable_releases = properties["stable_release"]
     stable_releases.sort(key=lambda x: LooseVersion(x["version"]))
-    stable_releases.reverse()
 
     if len(stable_releases) == 0:
         logger.info("No stable releases")


### PR DESCRIPTION
I'm a quite confused right now but it seems that the order is actually correct as we want it without the `reverse()` – right?
We want to add the newest 100 versions and we want to first add older versions and then newer.