### PR TITLE
GitHub Actions: fix poetry installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          curl -sSL https://install.python-poetry.org | python
           $HOME/.poetry/bin/poetry config virtualenvs.in-project true
       - uses: actions/cache@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install poetry
         run: |
           curl -sSL https://install.python-poetry.org | python
-          $HOME/.poetry/bin/poetry config virtualenvs.in-project true
+          poetry config virtualenvs.in-project true
       - uses: actions/cache@v1
         with:
           path: .venv
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             poetry-${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install depencies
-        run: $HOME/.poetry/bin/poetry install
+        run: poetry install
       - name: Check formatting
         run: .venv/bin/black . --check
       - name: Run pytest


### PR DESCRIPTION
Ref: https://python-poetry.org/docs/#installation

>  The previous get-poetry.py and install-poetry.py installers are deprecated. Any installs performed using get-poetry.py should be uninstalled and reinstalled using install.python-poetry.org to ensure in-place upgrades are possible.