### PR TITLE
Fix a broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ You can find detailed statistics on [wmflabs][wmflabs].
 [poetry]: https://github.com/sdispater/poetry
 [github-token]: https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 [repo-property]: https://www.wikidata.org/wiki/Property:P1324
-[no-repo-query]: https://github.com/konstin/github-wikidata-bot/blob/master/free_software_without_repository.rq
+[no-repo-query]: https://github.com/konstin/github-wikidata-bot/blob/main/src/free_software_without_repository.rq
 [wmflabs]: https://xtools.wmflabs.org/ec/wikidata/Github-wiki-bot
 [logs]: https://gist.github.com/konstin/9b90ae895ad9a270102415474a56e613


### PR DESCRIPTION
It was moved in https://github.com/konstin/github-wikidata-bot/commit/2c88e6f3633d4ca5bdb72c6242ddb1f36b4ad5f3.